### PR TITLE
using docker exec with existing container instead of spawning new contai...

### DIFF
--- a/check-cmd
+++ b/check-cmd
@@ -2,12 +2,10 @@
 
 main() {
 	local container_id="$1"; shift
-	local port="$1"; shift
+	local port="$1"; shift # not used for now but kept for compatibility of gliderlabs/registrator
 	local cmd="$@"
-
-	local image="$(docker inspect -f "{{.Config.Image}}" $container_id)"
-	local ip="$(docker inspect -f "{{.NetworkSettings.IPAddress}}" $container_id)"
-	docker run --rm --net container:$container_id -e "SERVICE_ADDR=$ip:$port" $image $cmd
+	echo "docker exec $container_id  $cmd"
+	docker exec $container_id  $cmd
 }
 
 main $@


### PR DESCRIPTION
Hi
I believe that health check script shall be run within "container to be checked" not from clone-container  attached to network stack of the "container to check". The health check script shall simply have access to a process tree, file system and rest of resources of "container to be checked" but by running it from a brand new container with network attached, no such an access except for networking is provided. For that case i would simply go for check-http script.