### PR TITLE
add some additional customization points

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN cd /bin && unzip /tmp/consul.zip && chmod +x /bin/consul && rm /tmp/consul.z
 ADD https://dl.bintray.com/mitchellh/consul/0.5.0_web_ui.zip /tmp/webui.zip
 RUN mkdir /ui && cd /ui && unzip /tmp/webui.zip && rm /tmp/webui.zip && mv dist/* . && rm -rf dist
 
-ADD https://get.docker.io/builds/Linux/x86_64/docker-1.5.0 /bin/docker
+ADD https://get.docker.io/builds/Linux/x86_64/docker-1.6.0 /bin/docker
 RUN chmod +x /bin/docker
 
 RUN opkg-install curl bash ca-certificates
@@ -29,3 +29,16 @@ ENV SHELL /bin/bash
 
 ENTRYPOINT ["/bin/start"]
 CMD []
+
+
+# some additional customization points:
+
+# in case of boot-strapping expect 3 server nodes by default
+ENV EXPECT 3
+
+# register for this datacenter
+ENV DC dc1
+
+# per default use the hostname of machine executing the 'docker run' command as
+# hostname of the consul container
+ENV CONSUL_HOSTNAME '$HOSTNAME'

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Outputs:
 		-d -v /mnt:/data \
 		progrium/consul -server -advertise 10.0.1.1 -join 10.0.1.2
 
-You may notice it lets you only run with bootstrap-expect or join, not both. Using `cmd:run` assumes you will be bootstrapping with the first node and expecting 3 nodes. You can change the expected peers before bootstrap by setting the `EXPECT` environment variable.
+You may notice it lets you only run with bootstrap-expect or join, not both. Using `cmd:run` assumes you will be bootstrapping with the first node and expecting 3 nodes. You can change the expected peers before bootstrap by setting the `EXPECT` environment variable (e.g., by `docker run --env='EXPECT=1' ...`).
 
 To use this convenience, you simply wrap the `cmd:run` output in a subshell. Run this to see it work:
 
@@ -167,6 +167,23 @@ To boot a client node using the runner command, append the string `::client` ont
 	$ docker run --rm progrium/consul cmd:run 10.0.1.4::10.0.1.2::client -d
 
 Would create the same output as above but without the `-server` consul argument.
+
+##### Additional customization
+
+There are several other additional customization points available, which are defined as `ENV` variables at the end of the `DOCKERFILE`. Currently available are:
+
+  - `EXPECT`: specifies the expected number of consul server nodes in case of bootstrapping. The default value is `3`, but you can set this value to `1` for testing environments.
+  - `DC`: specifies the datacenter the consul agent is associated with. The default value is `dc1`.
+  - `CONSUL_HOSTNAME`: specifies the hostname used for the created consul container. The default is to use the hostname of the machine the `docker run` command is executed on, but in case of remote execution of this command you might want to override this name.
+
+For example:
+
+	$ docker run --rm \
+	             --env="EXPECT=1" \
+	             --env="DC=my_datacenter" \
+	             --env="CONSUL_HOSTNAME=my_hostname" \
+	             progrium/consul \
+	             cmd:run 10.0.1.4::10.0.1.2 -d
 
 #### Health checking with Docker
 

--- a/start
+++ b/start
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 readonly IMAGE="progrium/consul"
-readonly EXPECT="${EXPECT:-3}"
 
 cmd-run() {
 	local ip_def="$1"; shift
@@ -23,7 +22,7 @@ cmd-run() {
 
 	bridge_ip="$(ip ro | awk '/^default/{print $3}')"
 	cat <<EOF
-eval docker run --name consul -h \$HOSTNAME \
+eval docker run --name consul -h $CONSUL_HOSTNAME \
 	-p $external_ip:8300:8300 \
 	-p $external_ip:8301:8301 \
 	-p $external_ip:8301:8301/udp \
@@ -34,7 +33,7 @@ eval docker run --name consul -h \$HOSTNAME \
 	-p $bridge_ip:53:53 \
 	-p $bridge_ip:53:53/udp \
 	$args \
-	$IMAGE $server_flag -advertise $external_ip $run_mode
+	$IMAGE $server_flag -advertise $external_ip -dc $DC $run_mode
 EOF
 }
 


### PR DESCRIPTION
add these 3 customisation points as explicit `ENV` variables to the `DOCKERFILE`:
  - `EXPECT`: specifies the expected number of consul server nodes in case of bootstrapping. The default value is `3`, but you can set this value to `1` for testing environments.
  - `DC`: specifies the datacenter the consul agent is associated with. The default value is `dc1`.
  - `CONSUL_HOSTNAME`: specifies the hostname used for the created consul container. The default is to use the hostname of the machine the `docker run` command is executed on, but in case of remote execution of this command you might want to override this name.

Without this addition my `consul install` command looks like this:

    HOSTNAME=my_hostname $(docker run --rm --env="EXPECT=1" progrium/consul cmd:run $DOCKER_IP --detach) -dc=my_dc

with 3 different places for defining the customizations. With this change it can be used in a more uniform manner like this:

    $(docker run --rm --env="EXPECT=1" --env="CONSUL_HOSTNAME=my_hostname" --env="DC=my_dc" progrium/consul cmd:run $DOCKER_IP --detach)