### PR TITLE
mimick option -recursor

### DIFF
--- a/start
+++ b/start
@@ -38,11 +38,37 @@ eval docker run --name consul -h \$HOSTNAME \
 EOF
 }
 
+#
+# Start agent, mimicking the -recursor option by modifying the default consul.json file.
+# This option is missing in v0.5 of consul.
+#
+function start-agent() {
+        local recursors
+        declare -a arguments
+
+        while [ $# -gt 0 ] ; do
+                argument="$1"; shift
+                if [ "$argument" == "-recursor" ] ; then
+                        [ -z "$recursors" ] && recursors="\"$1\"" || recursors="$recursors,\"$1\""
+                        shift
+                else
+                        arguments+=("$argument")
+                fi
+        done
+
+	if [ -n "$recursors" ] ; then
+		echo "INFO: changing the recursors in the default /config/consul.json" >&2
+		sed -i -e "s/\"recursor.*/\"recursors\" : [ $recursors ],/" /config/consul.json
+	fi
+
+	exec /bin/consul agent -config-dir=/config "${arguments[@]}"
+}
+
 main() {
 	set -eo pipefail
 	case "$1" in
-	cmd:run)            shift; cmd-run $@;;
-	*)                  exec /bin/consul agent -config-dir=/config $@;;
+	cmd:run)            shift; cmd-run "$@";;
+	*)                  start-agent "$@";;
 	esac
 }
 


### PR DESCRIPTION
I am running consul in a VPC in AWS in which access 8.8.8.8 is disallowed and the internal DNS server should be used. In a future version of consul (not 0.5), this can be specified with the -precursor option. 

This -precursor option is now mimicked by removing the  option from the command line and modifying the consul.json file in the image at start time.

Would also provide a way to solve https://github.com/progrium/docker-consul/issues/56

You can test this option by pulling the repository cargonauts/progrium-consul. I have tested it and it works to my satisfaction :-)